### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows Arduino/Genuino boards to easily work with a variable number of 
 paragraph=Variable number of IR sensors attached<br />Takes care of measurements and sensor order<br />Displays results on OLED display<br />
 category=Sensors
 url=https://github.com/mstoyanov1/IR_Accelerating_Motion
-architectures=all
+architectures=*


### PR DESCRIPTION
The previous architectures value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library IR_Accelerating_Motion claims to run on (all) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the File > Examples > INCOMPATIBLE menu.