### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-AcceleratingMotion KEYWORD1	IR
+AcceleratingMotion	KEYWORD1	IR
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin            KEYWORD2
-readPins	 KEYWORD2
-displayPinStats	 KEYWORD2
-read	         KEYWORD2
-debug	         KEYWORD2
+begin	KEYWORD2
+readPins	KEYWORD2
+displayPinStats	KEYWORD2
+read	KEYWORD2
+debug	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords